### PR TITLE
fix path to install bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ cd ~ && git clone --depth 1 https://github.com/sblaurock/tarmak-layouts.git && c
 ```
 
 ## Manual Install
-Simply unpack the relevant *.tar.gz* file and copy the bundle to */Volumes/Keyboard Layouts/*.
+Simply unpack the relevant *.tar.gz* file and copy the bundle to */Library/Keyboard Layouts/*.
 
 ## Note
 Colemak calls for remapping the caps lock key to backspace, however neither the Tarmak layouts in this repository nor the integrated OS X Colemak layout provide this functionality. You can look to [Seil](https://pqrs.org/osx/karabiner/seil.html.en) to allow for this if desired.


### PR DESCRIPTION
## What does this do?
Makes a tiny tweak to the layout installation path

## Why did you do this?
`/Volumes/Keyboard Layout/` does not exist in a normal MacOS installation.

## Tests performed
Copied bundle to /Library/Keyboard Layouts/ on my own machine, and was able to switch to Tarmak layout.